### PR TITLE
Setup via Esy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,9 @@
 .DS_Store
 _build
+_release
+_esy
 .merlin
+node_modules/
+*.byte
+*.native
+*.install

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "reason_language_server.per_value_codelens": true,
+  "reason_language_server.opens_codelens": true,
+  "reason.codelens.enabled": true
+}

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ This material is intended for the [ReasonML CPH meetup Nov 28th 2018](https://ww
 
 ## Setup (esy)
 
-- yarn global add esy@next / npm install -g esy@next
-- esy
+- `yarn global add esy@next / npm install -g esy@next`
+- `esy`
 
 ## Run (esy)
 
-- esy x graphql-server-workshop-2018
+- `esy x server`
 
 ## Setup (Trusty ol' way)
 
@@ -23,7 +23,7 @@ Installation instructions for Reason: https://reasonml.github.io/docs/en/install
 
 ## Run (Trusty ol' way)
 
-- dune exec src/server/server.exe
+- `dune exec src/server/server.exe`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This material is intended for the [ReasonML CPH meetup Nov 28th 2018](https://ww
 
 ## Setup (esy)
 
-- yarn global add esy / npm install -g esy
+- yarn global add esy@next / npm install -g esy@next
 - esy
 
 ## Run (esy)

--- a/README.md
+++ b/README.md
@@ -2,16 +2,30 @@
 
 This material is intended for the [ReasonML CPH meetup Nov 28th 2018](https://www.meetup.com/ReasonML-CPH/events/256170465/).
 
-## Setup
+## Setup (esy)
+
+- yarn global add esy / npm install -g esy
+- esy
+
+## Run (esy)
+
+- esy x graphql-server-workshop-2018
+
+## Setup (Trusty ol' way)
 
 - OCaml 4.07.1, or ReasonML 3.0.4
 - OPAM 2.0.1
 - OPAM packages: dune, graphql-lwt, px_deriving_yojson
 
-
 Installation instructions for OCaml: https://medium.com/@bobbypriambodo/getting-your-feet-wet-with-ocaml-ea1045b6efbc
 
 Installation instructions for Reason: https://reasonml.github.io/docs/en/installation
+
+## Run (Trusty ol' way)
+
+- dune exec src/server/server.exe
+
+---
 
 We recommend installing [VSCode](https://code.visualstudio.com/) and a suitable extension for OCaml/ReasonML.
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "graphql-server-workshop-2018",
+  "version": "0.0.1",
+  "description": "",
+  "license": "MIT",
+  "esy": {
+    "build": "refmterr dune build -p #{self.name}"
+  },
+  "dependencies": {
+    "ocaml": "~4.6.0",
+    "@opam/dune": "*",
+    "@opam/cohttp-lwt-unix": "*",
+    "@opam/ppx_deriving_yojson": "*",
+    "@opam/graphql": "*",
+    "@opam/graphql-lwt": "*",
+    "@esy-ocaml/reason": "*",
+    "refmterr": "*"
+  },
+  "resolutions:NOTE": "This is how you override dependency resolution",
+  "resolutions": {
+    "@esy-ocaml/esy-installer": "0.0.1",
+    "@opam/menhir": "20171013",
+    "@opam/re": "1.8.0"
+  },
+  "devDependencies": {
+    "@esy-ocaml/merlin": "*",
+    "ocaml": "~4.6.0"
+  }
+}

--- a/src/server/dune
+++ b/src/server/dune
@@ -1,4 +1,5 @@
 (executable
   (name server)
+  (public_name graphql-server-workshop-2018)
   (libraries graphql graphql-lwt geotypes)
 )

--- a/src/server/dune
+++ b/src/server/dune
@@ -1,5 +1,5 @@
 (executable
   (name server)
-  (public_name graphql-server-workshop-2018)
+  (public_name server)
   (libraries graphql graphql-lwt geotypes)
 )


### PR DESCRIPTION
Simplifies setup for people not familiar with the OCaml ecosystem with a workflow that is more familiar to Node/JavaScript developers. Read more: https://esy.sh

If you're using VSCode this currently only works with the following extension: [OCaml and Reason IDE](https://marketplace.visualstudio.com/items?itemName=freebroccolo.reasonml)

There's possibly a bug in reason-vscode which is why we don't currently recommend it. Follow along here: https://github.com/jaredly/reason-language-server